### PR TITLE
Better signal handling for docker-test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,14 +45,12 @@ build-docker-test:
 	docker build -t knamespacertest:dev -f testing.Dockerfile .
 docker-test: build-docker-test
 	docker run -it --rm -v "$(shell pwd):$(shell pwd)" -w "$(shell pwd)" knamespacertest:dev \
-	/bin/bash -c "make test"
+	/usr/bin/dumb-init make test
 docker-e2e-test: build-docker-test
 	docker run -it --rm -v "$(shell pwd):$(shell pwd)" -w "$(shell pwd)" knamespacertest:dev \
-	/bin/bash -c "make e2e-test"
-docker-test-shell:
+	/usr/bin/dumb-init make e2e-test
+docker-test-shell: build-docker-test
 	docker run -it --rm -v "$(shell pwd):$(shell pwd)" -w "$(shell pwd)" knamespacertest:dev \
 	/bin/bash
 docker-run: build-docker
 	docker run -it --rm -v "${HOME}/.kube/:/root/.kube/" knamespacer:dev 
-# e2e-test:
-# 	venom run e2e/tests/* --output-dir e2e/results --log info --strictf

--- a/testing.Dockerfile
+++ b/testing.Dockerfile
@@ -2,8 +2,8 @@ FROM golang:1.22
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-RUN setup-envtest use
+RUN apt update && apt upgrade -y && apt install dumb-init -y
+RUN go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && setup-envtest use
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
- using dumb-init to properly plumb signals on docker test runs

Realized that if you control-c during a docker-test run, it will hang until you kill the container. This was just caused by me using bash as the initial process, which doesn't correctly route SIGKILL/SIGTERM. Swapped it out with dumb-init, which is an initialization system for containers that handles this kind of signal plumbing 